### PR TITLE
Fix width and height handling in stored image.

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -292,8 +292,8 @@ abstract class AbstractProvider implements ProviderInterface
         $imageSize = getimagesize($file->getRealPath());
         if (is_array($imageSize)) {
             if (is_int($imageSize[0]) && is_int($imageSize[1])) {
-                $fileData['height'] = $imageSize[0];
-                $fileData['width']  = $imageSize[1];
+                $fileData['width']  = $imageSize[0];
+                $fileData['height'] = $imageSize[1];
             }
             if (isset($imageSize['bits'])) {
                 $fileData['bits'] = $imageSize['bits'];


### PR DESCRIPTION
`getimagesize` says ` * Index 0 and 1 contains respectively the width and the height of the image.`