### PR TITLE
Bugfix: Force SSL to YouTube provider

### DIFF
--- a/src/Provider/YouTubeProvider.php
+++ b/src/Provider/YouTubeProvider.php
@@ -6,7 +6,7 @@ use MediaMonks\SonataMediaBundle\Exception\InvalidProviderUrlException;
 
 class YouTubeProvider extends AbstractOembedProvider implements ProviderInterface, EmbeddableProviderInterface
 {
-    const URL_OEMBED = 'http://www.youtube.com/oembed?url=http://www.youtube.com/watch?v=%s&format=json';
+    const URL_OEMBED = 'https://www.youtube.com/oembed?url=http://www.youtube.com/watch?v=%s&format=json';
     const URL_IMAGE_MAX_RES = 'https://i.ytimg.com/vi/%s/maxresdefault.jpg';
     const URL_IMAGE_HQ = 'https://i.ytimg.com/vi/%s/hqdefault.jpg';
 


### PR DESCRIPTION
SSL is required since 2021. Can you please merge this and tag it as 2.0.6? Thanks! This PR makes it working again.